### PR TITLE
Add support for City Chain

### DIFF
--- a/docker/city/docker-compose.yml
+++ b/docker/city/docker-compose.yml
@@ -3,8 +3,9 @@ services:
   nako:
     container_name: city-nako
     networks: 
-        - city
-    image: coinvault/nako:core
+        nakonet:
+            ipv4_address: 172.16.10.100
+    image: coinvault/nako
     command: city
     ports: 
         - 9019:9000
@@ -14,17 +15,23 @@ services:
   client:
     container_name: city-client
     networks: 
-        - city
+        nakonet:
+            ipv4_address: 172.16.10.101
     image: citychain/citychain
-    command: ["-server=1", "-rpcallowip=0.0.0.0", "-rpcport=5000", "-rpcuser=rpcuser", "-rpcpassword=rpcpassword", "-rpcthreads=300", "-txindex=1"]
+    command: ["-server=1", "-rpcallowip=172.16.10.100", "-rpcbind=172.16.10.101", "-rpcport=5000", "-rpcuser=rpcuser", "-rpcpassword=rpcpassword", "-rpcthreads=300", "-txindex=1"]
     ports: 
         - 5019:5000
         - 4333:4333
   mongo:
     container_name: city-mongo
     networks: 
-        - city
+        nakonet:
+            ipv4_address: 172.16.10.102
     image: mongo:3.2
 networks:
-    city:
-      driver: bridge
+  nakonet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.10.0/24

--- a/docker/city/docker-compose.yml
+++ b/docker/city/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '2'
+services:
+  nako:
+    container_name: city-nako
+    networks: 
+        citynet:
+            ipv4_address: 70.28.5.200
+    image: coinvault/nako
+    command: city
+    ports: 
+        - 9019:9000
+    depends_on:
+        - mongo
+        - client
+  client:
+    container_name: city-client
+    networks: 
+        citynet:
+            ipv4_address: 70.28.5.199
+    image: citychain/citychain
+    command: ["-server=1", "-rpcbind=70.28.5.199", "-rpcallowip=70.28.5.200", "-rpcport=5000", "-rpcuser=rpcuser", "-rpcpassword=rpcpassword", "-rpcthreads=300", "-txindex=1"]
+    ports: 
+        - 5019:5000
+        - 4333:4333
+  mongo:
+    container_name: city-mongo
+    networks: 
+        citynet:
+            ipv4_address: 70.28.5.198
+    image: mongo:3.2
+networks:
+  citynet:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 70.28.0.0/16

--- a/docker/city/docker-compose.yml
+++ b/docker/city/docker-compose.yml
@@ -3,9 +3,8 @@ services:
   nako:
     container_name: city-nako
     networks: 
-        citynet:
-            ipv4_address: 70.28.5.200
-    image: coinvault/nako
+        - city
+    image: coinvault/nako:core
     command: city
     ports: 
         - 9019:9000
@@ -15,23 +14,17 @@ services:
   client:
     container_name: city-client
     networks: 
-        citynet:
-            ipv4_address: 70.28.5.199
+        - city
     image: citychain/citychain
-    command: ["-server=1", "-rpcbind=70.28.5.199", "-rpcallowip=70.28.5.200", "-rpcport=5000", "-rpcuser=rpcuser", "-rpcpassword=rpcpassword", "-rpcthreads=300", "-txindex=1"]
+    command: ["-server=1", "-rpcallowip=0.0.0.0", "-rpcport=5000", "-rpcuser=rpcuser", "-rpcpassword=rpcpassword", "-rpcthreads=300", "-txindex=1"]
     ports: 
         - 5019:5000
         - 4333:4333
   mongo:
     container_name: city-mongo
     networks: 
-        citynet:
-            ipv4_address: 70.28.5.198
+        - city
     image: mongo:3.2
 networks:
-  citynet:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 70.28.0.0/16
+    city:
+      driver: bridge


### PR DESCRIPTION
- Use the official City Chain docker image for daemon.
- Need to use static IP due to rpcallowip not supporting * or 0.0.0.0/0 just yet.